### PR TITLE
User can start tracking available trials

### DIFF
--- a/TimedTrials/Controllers/UserTrialController.cs
+++ b/TimedTrials/Controllers/UserTrialController.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Security.Claims;
 using Microsoft.AspNetCore.Mvc;
 using TimedTrials.Repositories;
@@ -24,9 +25,22 @@ namespace TimedTrials.Controllers
         [HttpGet]
         public IActionResult Get()
         {
-            var currentUserProfile  = GetCurrentUserProfile();
+            var currentUserProfile = GetCurrentUserProfile();
             var userId = currentUserProfile.Id;
             return Ok(_userTrialRepository.GetActiveUserTrials(userId));
+        }
+
+        [HttpPost("{trialId}")]
+        public IActionResult Add(int trialId)
+        {
+            UserTrial userTrial = new UserTrial();
+            var currentUserProfile = GetCurrentUserProfile();
+            userTrial.TrialId = trialId;
+            userTrial.UserId = currentUserProfile.Id;
+            userTrial.TrialStartDate = DateTime.Now;
+            userTrial.SubscriptionActive = true;
+            _userTrialRepository.AddUserTrial(userTrial);
+            return Ok(userTrial);
         }
 
         private UserProfile GetCurrentUserProfile()

--- a/TimedTrials/Repositories/IUserTrialRepository.cs
+++ b/TimedTrials/Repositories/IUserTrialRepository.cs
@@ -5,6 +5,7 @@ namespace TimedTrials.Repositories
 {
     public interface IUserTrialRepository
     {
+        void AddUserTrial(UserTrial userTrial);
         List<UserTrial> GetActiveUserTrials(int id);
     }
 }

--- a/TimedTrials/Repositories/UserTrialRepository.cs
+++ b/TimedTrials/Repositories/UserTrialRepository.cs
@@ -47,7 +47,7 @@ namespace TimedTrials.Repositories
                                 },                                
                                 TrialId = DbUtils.GetInt(reader, "TrialId"),
                                 TrialStartDate = DbUtils.GetDateTime(reader, "TrialStartDate"),
-                                SubscriptionActive = DbUtils.GetBool(reader, "SubscriptionActive"),
+                                SubscriptionActive = reader.GetBoolean(reader.GetOrdinal("SubscriptionActive")),
                                 Trial = new Trial()
                                 {
                                     Id = DbUtils.GetInt(reader, "TrialId"),
@@ -61,11 +61,32 @@ namespace TimedTrials.Repositories
                                         Name = DbUtils.GetString(reader, "WebsiteName"),
                                         Url = DbUtils.GetString(reader, "WebsiteUrl")
                                     }
-                                }
+                                },
+                                
                             });
                         }
                         return userTrials;
                     }
+                }
+            }
+        }
+        public void AddUserTrial(UserTrial userTrial)
+        {
+            using (var conn = Connection)
+            {
+                conn.Open();
+                using (var cmd = conn.CreateCommand())
+                {
+                    cmd.CommandText = @"INSERT INTO UserTrial (UserId, TrialId, TrialStartDate, SubscriptionActive)
+                                        OUTPUT Inserted.Id
+                                        VALUES (@UserId, @TrialId, @TrialStartDate, @SubscriptionActive)";
+
+                    DbUtils.AddParameter(cmd, "@UserId", userTrial.UserId);
+                    DbUtils.AddParameter(cmd, "@TrialId", userTrial.TrialId);
+                    DbUtils.AddParameter(cmd, "@TrialStartDate", userTrial.TrialStartDate);
+                    DbUtils.AddParameter(cmd, "@SubscriptionActive", userTrial.SubscriptionActive);
+
+                    userTrial.Id = (int)cmd.ExecuteScalar();
                 }
             }
         }

--- a/TimedTrials/client/src/components/TrialList.js
+++ b/TimedTrials/client/src/components/TrialList.js
@@ -1,19 +1,48 @@
 import React, { useEffect, useState } from "react";
-import { ListGroup, ListGroupItem } from "reactstrap";
+import { ListGroup, ListGroupItem, Button } from "reactstrap";
 import { Link } from "react-router-dom";
 import Trial from "./Trial";
 import { getAllTrials } from "../modules/trialManager";
+import {
+  getAllCurrentUserTrials,
+  addUserTrial,
+} from "../modules/userTrialManager";
 
 const TrialList = () => {
+  const [userTrials, setCurrentUserTrials] = useState([]);
   const [trials, setTrials] = useState([]);
-
+  const [render, setRender] = useState(1);
   const getTrials = () => {
     getAllTrials().then((trials) => setTrials(trials));
   };
-
+  const getUserTrials = () => {
+    getAllCurrentUserTrials().then((userTrials) =>
+      setCurrentUserTrials(userTrials)
+    );
+  };
   useEffect(() => {
+    getUserTrials();
     getTrials();
-  }, []);
+  }, [render]);
+
+  const displayTrackingButton = (id) => {
+    const idCheck = userTrials.find((userTrial) => userTrial.trialId === id);
+    if (idCheck) {
+      return null;
+    } else {
+      return (
+        <Button id={id} onClick={subscriptionButtonHandler}>
+          Started Subscription?
+        </Button>
+      );
+    }
+  };
+
+  const subscriptionButtonHandler = (evt) => {
+    evt.preventDefault();
+    addUserTrial(evt.target.id);
+    setRender(render + 1);
+  };
 
   return (
     <div className="container">
@@ -24,7 +53,10 @@ const TrialList = () => {
             return (
               <ListGroupItem key={trial.id}>
                 <Trial trial={trial} />
-                <Link to={`/trial/delete/${trial.id}`}>Delete</Link>
+                {displayTrackingButton(trial.id)}
+                <Link to={`/trial/delete/${trial.id}`}>
+                  <Button>Delete Trial</Button>
+                </Link>
               </ListGroupItem>
             );
           })}

--- a/TimedTrials/client/src/components/UserTrial.js
+++ b/TimedTrials/client/src/components/UserTrial.js
@@ -9,6 +9,8 @@ const UserTrial = ({ userTrial }) => {
           <p>This is a test.</p>
           <p>{userTrial.trial.website.name}</p>
           <p>{userTrial.trial.website.url}</p>
+          <p>{userTrial.trial.trialDuration}</p>
+          <p>{userTrial.trialEndDate}</p>
         </CardBody>
       </div>
     </Card>

--- a/TimedTrials/client/src/modules/userTrialManager.js
+++ b/TimedTrials/client/src/modules/userTrialManager.js
@@ -18,3 +18,23 @@ export const getAllCurrentUserTrials = () => {
     });
   });
 };
+export const addUserTrial = (trialId) => {
+  return getToken().then((token) => {
+    return fetch(`${_apiUrl}/${trialId}`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${token}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(trialId),
+    }).then((resp) => {
+      if (resp.ok) {
+        return resp.json();
+      } else {
+        throw new Error(
+          "An error occured adding new trial to user's trial list"
+        );
+      }
+    });
+  });
+};


### PR DESCRIPTION
#### Changes Made
1. Added button to Trial List on each Trial card that allows user to add trial to their UserTrials
2. Added function that conditionally renders the button based on the current logged in user's current active user trials
3. Added Controller method that builds a new UserTrial object with the trialId given from the client app
4. Added Repository method and interface for adding a UserTrial
​
#### Steps to Review
1. Checkout this branch locally.
    ```
    git fetch --all
    git checkout bb-AddingUserTrials
    ```
7. Open a new Terminal tab (⌘T) and navigate to the server directory.
8. Test app functionality.
    >GIVEN a user would like to start tracking a new trial
WHEN the user clicks on the Trials link
THEN they are directed to a view with a list of trials being offered
WHEN the user clicks the "Subscription Started" button on a trial card
THEN the trial will be added to that user's trial tracking list
9. View code file.
    > Confirm file modifications are present as indicated above.
    > Confirm no unused code or extraneous comments exist.

closes issue #5   